### PR TITLE
Fix #29 Add cifs-utils to allow mounting fileshares

### DIFF
--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -24,7 +24,9 @@ yum -y install \
   make \
   git \
   epel-release \
-  curl
+  curl \
+  python-setuptools
+
 
 # Install Docker (https://docs.docker.com/engine/installation/linux/centos/#install-with-yum)
 sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'

--- a/iso/Dockerfile
+++ b/iso/Dockerfile
@@ -32,6 +32,17 @@ ADD nsenter $ROOTFS/usr/bin/
 ADD socat $ROOTFS/usr/bin
 ADD ethtool $ROOTFS/usr/bin
 ADD conntrack $ROOTFS/usr/bin
+
+# Add cifs-utils to mount fileshares
+ENV CIFS_DEPS cifs-utils \
+              samba-libs
+
+RUN for dep in $CIFS_DEPS; do \
+        curl -fSL -o "/tmp/$dep.tcz" "$TCL_REPO_BASE/tcz/$dep.tcz"; \
+        unsquashfs -f -d "$ROOTFS" "/tmp/$dep.tcz"; \
+        rm -f "/tmp/$dep.tcz"; \
+    done
+
 ADD bootlocal.sh $ROOTFS/tmp/bootlocal.sh
 RUN cat $ROOTFS/tmp/bootlocal.sh >> $ROOTFS/etc/rc.d/automount
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -56,6 +56,11 @@ class MinishiftISOTest(Test):
         output = self.execute_test({ 'cmd': cmd })
         self.check_data_evaluable(output.rstrip())
 
+    def test_cifs_mount(self):
+        cmd = self.bin_dir + "minishift ssh 'sudo /sbin/mount.cifs -V'"
+        output = self.execute_test({ 'cmd': cmd })
+        self.assertEqual('mount.cifs version: 6.2', output.rstrip())
+
     def test_stopping_vm(self):
         ''' Test stopping machine '''
         cmd = self.bin_dir + "minishift stop"


### PR DESCRIPTION
Added `cifs-utils` and dependencies into `/rootfs/`. This allows mounting of fileshares using the smb protocol.