### PR TITLE
Fixes #44 Add nfs-utils

### DIFF
--- a/iso/Dockerfile
+++ b/iso/Dockerfile
@@ -36,7 +36,8 @@ ADD conntrack $ROOTFS/usr/bin
 # Add cifs-utils and sshfs-fuse to mount fileshares
 ENV HOST_FOLDER_DEPS cifs-utils \
               samba-libs \
-              sshfs-fuse
+              sshfs-fuse \
+              nfs-utils
 
 RUN for dep in $HOST_FOLDER_DEPS; do \
         curl -fSL -o "/tmp/$dep.tcz" "$TCL_REPO_BASE/tcz/$dep.tcz"; \

--- a/tests/test.py
+++ b/tests/test.py
@@ -66,6 +66,13 @@ class MinishiftISOTest(Test):
         output = self.execute_test({ 'cmd': cmd })
         self.assertRegexpMatches(output.rstrip(), r'.*SSHFS version 2\.5.*')
 
+    # mount.nfs -V does not return a version
+    # current test fails because `minishift ssh` https://github.com/minishift/minishift/issues/660
+    #def test_nfs_installed(self):
+    #    cmd = self.bin_dir + "minishift ssh 'sudo /sbin/mount.nfs'"
+    #    output = self.execute_test({ 'cmd': cmd })
+    #    self.assertRegexpMatches(output.rstrip(), r'-o nfsoptions')
+
     def test_stopping_vm(self):
         ''' Test stopping machine '''
         cmd = self.bin_dir + "minishift stop"


### PR DESCRIPTION
Fixes #44 

Has an issue with tests:

  * `mount.nfs -V` does not return the expected version details
  * `minishift ssh `sudo /sbin/mount.nfs` errors due to https://github.com/minishift/minishift/issues/660

Therefore the testcase is commented