### PR TITLE
Issue #64 build, pull and push of container images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,11 +2,15 @@ build:
   image: fedora:26
   variables:
     DOCKER_HOST: "tcp://gbraad__dind-options:2375"
+    BUILD_CONTAINER_IMAGES: y
+    PUSH_CONTAINER_IMAGES: y
     REMOVE_CONTAINER_IMAGES: y
   services:
     - gbraad/dind-options:latest
-  script:
+  before_script:
     - dnf install -y docker make git gettext
+    - docker login -u gbraad -p $DOCKER_PASSWORD
+  script:
     - make
     - mv ./build ./public
   artifacts:

--- a/iso/build.sh
+++ b/iso/build.sh
@@ -31,22 +31,25 @@ docker run $DOCKER_RUN_OPTIONS jpetazzo/nsenter cat /nsenter > $tmpdir/nsenter &
 # do not remove nsenter, as this image is not big, and quite generally used
 
 # Get socat
-docker build -t socat -f Dockerfile.socat .
-docker run $DOCKER_RUN_OPTIONS socat cat socat > $tmpdir/socat
+[ "${BUILD_CONTAINER_IMAGES+1}" ] && docker build -t minishift/b2d-socat -f Dockerfile.socat .
+docker run $DOCKER_RUN_OPTIONS minishift/b2d-socat cat socat > $tmpdir/socat
 chmod +x $tmpdir/socat
-[ "${REMOVE_CONTAINER_IMAGES+1}" ] && docker rmi socat
+[ "${PUSH_CONTAINER_IMAGES+1}" ] && docker push minishift/b2d-socat
+[ "${REMOVE_CONTAINER_IMAGES+1}" ] && docker rmi minishift/b2d-socat
 
 # Get ethtool
-docker build -t ethtool -f Dockerfile.ethtool .
-docker run $DOCKER_RUN_OPTIONS ethtool cat ethtool > $tmpdir/ethtool
+[ "${BUILD_CONTAINER_IMAGES+1}" ] && docker build -t minishift/b2d-ethtool -f Dockerfile.ethtool .
+docker run $DOCKER_RUN_OPTIONS minishift/b2d-ethtool cat ethtool > $tmpdir/ethtool
 chmod +x $tmpdir/ethtool
-[ "${REMOVE_CONTAINER_IMAGES+1}" ] && docker rmi ethtool
+[ "${PUSH_CONTAINER_IMAGES+1}" ] && docker push minishift/b2d-ethtool
+[ "${REMOVE_CONTAINER_IMAGES+1}" ] && docker rmi minishift/b2d-ethtool
 
 # Get conntrack
-docker build -t conntrack -f Dockerfile.conntrack .
-docker run $DOCKER_RUN_OPTIONS conntrack cat conntrack > $tmpdir/conntrack
+[ "${BUILD_CONTAINER_IMAGES+1}" ] && docker build -t minishift/b2d-conntrack -f Dockerfile.conntrack .
+docker run $DOCKER_RUN_OPTIONS minishift/b2d-conntrack cat conntrack > $tmpdir/conntrack
 chmod +x $tmpdir/conntrack
-[ "${REMOVE_CONTAINER_IMAGES+1}" ] && docker rmi conntrack
+[ "${PUSH_CONTAINER_IMAGES+1}" ] && docker push minishift/b2d-conntrack
+[ "${REMOVE_CONTAINER_IMAGES+1}" ] && docker rmi minishift/b2d-conntrack
 
 # Do the build.
 docker build -t b2diso .


### PR DESCRIPTION
Fix #64 

Will have to remove/replace

```
  - docker login -u gbraad -p $DOCKER_PASSWORD
```

but this is something I used before to prevent the rebuild of the images for socat, ethtool, etc